### PR TITLE
Check if Slack command is null

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,32 +6,32 @@ object Dependencies {
 
   val TestLib = Seq(
     libraryDependencies ++= Seq(
-      "org.scalameta" %% "munit"         % "0.7.29" % Test,
-      "org.mockito"    % "mockito-core"  % "4.8.1"  % Test,
-      "org.gnieh"     %% "diffson-circe" % "4.3.0"
+      "org.scalameta" %% "munit"         % "0.7.+" % Test,
+      "org.mockito"    % "mockito-core"  % "5.1.+" % Test,
+      "org.gnieh"     %% "diffson-circe" % "4.3.+"
     ),
     testFrameworks += new TestFramework("munit.Framework")
   )
 
   val Slack = Seq(
-    libraryDependencies += "com.slack.api" % "slack-app-backend" % "1.26.1"
+    libraryDependencies += "com.slack.api" % "slack-app-backend" % "1.27.+"
   )
 
   val Refined = Seq(
-    libraryDependencies += "eu.timepit" %% "refined" % "0.10.1"
+    libraryDependencies += "eu.timepit" %% "refined" % "0.10.+"
   )
 
   val Logging = Seq(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "log4cats-slf4j"  % "2.5.0",
-      "ch.qos.logback" % "logback-classic" % "1.4.4" % Test,
-      "ch.qos.logback" % "logback-core"    % "1.4.4" % Test,
-      "org.slf4j"      % "jcl-over-slf4j"  % "2.0.3" % Test,
-      "org.slf4j"      % "jul-to-slf4j"    % "2.0.3" % Test
+      "org.typelevel" %% "log4cats-slf4j"  % "2.5.+",
+      "ch.qos.logback" % "logback-classic" % "1.4.+" % Test,
+      "ch.qos.logback" % "logback-core"    % "1.4.+" % Test,
+      "org.slf4j"      % "jcl-over-slf4j"  % "2.0.+" % Test,
+      "org.slf4j"      % "jul-to-slf4j"    % "2.0.+" % Test
     )
   )
 
-  val Http4sVersion = "0.23.12"
+  val Http4sVersion = "0.23.+"
   val Http4s = Seq(
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-dsl"          % Http4sVersion,
@@ -41,7 +41,7 @@ object Dependencies {
     )
   )
 
-  val CirceVersion = "0.14.1"
+  val CirceVersion = "0.14.+"
   val Circe = Seq(
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core"           % CirceVersion,

--- a/src/main/scala/io/laserdisc/slack4s/slashcmd/Models.scala
+++ b/src/main/scala/io/laserdisc/slack4s/slashcmd/Models.scala
@@ -34,6 +34,11 @@ sealed trait AuthError extends Throwable
 case class MissingHeader(headerName: String) extends AuthError {
   override def getMessage: String = s"Missing header: $headerName"
 }
+
+sealed trait PayloadError extends Throwable
+case class MissingPayloadField(error: String) extends PayloadError {
+  override def getMessage: String = s"Missing payload field error: $error"
+}
 case class BadSignature(timestamp: String, body: String, signature: String) extends AuthError {
   override def getMessage: String =
     s"Bad signature:$signature, for timestamp:$timestamp and body:$body"

--- a/src/main/scala/io/laserdisc/slack4s/slashcmd/SlashCommandBotBuilder.scala
+++ b/src/main/scala/io/laserdisc/slack4s/slashcmd/SlashCommandBotBuilder.scala
@@ -109,7 +109,7 @@ class SlashCommandBotBuilder[F[_]: Async] private[slashcmd] (
           .flatMap(_ => InternalServerError("Something went wrong, see the logs."))
     }
 
-  def buildHttpApp(cmdRunner: CommandRunner[F]): HttpApp[F] =
+  def buildHttpRoutes(cmdRunner: CommandRunner[F]): HttpRoutes[F] =
     Router(
       s"${endpointRoot.value}healthCheck" -> HttpRoutes.of[F] { case GET -> Root =>
         Ok.apply(s"OK")
@@ -119,6 +119,8 @@ class SlashCommandBotBuilder[F[_]: Async] private[slashcmd] (
           cmdRunner.processRequest(req)
         }
       )
-    ).orNotFound
+    )
 
+  def buildHttpApp(cmdRunner: CommandRunner[F]): HttpApp[F] =
+    buildHttpRoutes(cmdRunner).orNotFound
 }

--- a/src/main/scala/io/laserdisc/slack4s/slashcmd/package.scala
+++ b/src/main/scala/io/laserdisc/slack4s/slashcmd/package.scala
@@ -1,5 +1,6 @@
 package io.laserdisc.slack4s
 
+import cats.data.Validated
 import com.slack.api.app_backend.slash_commands.payload.SlashCommandPayload
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.numeric.Positive
@@ -23,5 +24,9 @@ package object slashcmd {
   object EndpointRoot  extends RefinedTypeOps[EndpointRoot, String]
 
   type CommandMapper[F[_]] = SlashCommandPayload => F[Command[F]]
+
+  implicit def validCommand(commandPayload: SlashCommandPayload): Validated[PayloadError, SlashCommandPayload] =
+    if (commandPayload.getCommand == null) Validated.invalid(MissingPayloadField("Command field was null"))
+    else Validated.valid(commandPayload)
 
 }

--- a/src/test/scala/io/laserdisc/slack4s/slashcmd/SlashCommandSuite.scala
+++ b/src/test/scala/io/laserdisc/slack4s/slashcmd/SlashCommandSuite.scala
@@ -27,6 +27,7 @@ trait SlashCommandSuite extends FunSuite {
 
   def signedSlashCmdRequest(
       text: String,
+      command: String = "hello",
       signingSecret: SigningSecret = DefaultTestSigningSecret,
       currentTimeMS: Long = System.currentTimeMillis(),
       responseURL: String = DefaultResponseUrl,
@@ -37,6 +38,7 @@ trait SlashCommandSuite extends FunSuite {
     // subset of the SlashPayloadCommand payload fields
     val payload = UrlForm(
       "text"         -> text,
+      "command"      -> command,
       "response_url" -> responseURL,
       "team_id"      -> userID,
       "user_id"      -> teamID

--- a/src/test/scala/io/laserdisc/slack4s/slashcmd/internal/SignatureValidatorTest.scala
+++ b/src/test/scala/io/laserdisc/slack4s/slashcmd/internal/SignatureValidatorTest.scala
@@ -42,7 +42,7 @@ class SignatureValidatorTest extends SlashCommandSuite {
 
   }
 
-  test("HTTP 401 if a null command is received") {
+  test("HTTP 400 if a null command is received") {
 
     val payload     = UrlForm("text" -> "whatever")
     val signatureTS = System.currentTimeMillis().toString


### PR DESCRIPTION
Would fix #77 using option 2.
If maintainers would prefer option 1, this PR would allow that: [#77](https://github.com/laserdisc-io/slack4s/pull/77)

I also added a http4s HttpRoutes option in addition to the HttpApp option because we wanted to combine these routes with other functionality